### PR TITLE
Fallback to paper trading when IBKR unavailable

### DIFF
--- a/app/api/ibkr/connect/route.ts
+++ b/app/api/ibkr/connect/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { IBApi, EventName } from '@stoqey/ib';
 
 interface IBKRConnectionRequest {
   host: string;
@@ -9,6 +8,25 @@ interface IBKRConnectionRequest {
 
 export async function POST(request: NextRequest) {
   try {
+    let IBApi: any;
+    let EventName: any;
+    try {
+      // Dynamically require the IBKR library if available
+      const ibModule = eval("require('@stoqey/ib')");
+      IBApi = ibModule.IBApi;
+      EventName = ibModule.EventName;
+    } catch (err) {
+      console.warn('IBKR library not found, falling back to virtual trading');
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'IBKR module not available',
+          fallbackMode: 'virtual',
+        },
+        { status: 503 }
+      );
+    }
+
     const { host, port, clientId }: IBKRConnectionRequest = await request.json();
 
     return await new Promise<NextResponse>((resolve) => {

--- a/app/dashboard/trading/paper/page.tsx
+++ b/app/dashboard/trading/paper/page.tsx
@@ -138,11 +138,13 @@ export default function PaperTradingPage() {
         }));
         console.log('✅ Connected to IBKR TWS Paper Trading');
       } else {
-        throw new Error('IBKR connection failed');
+        // Connection failed, fallback to virtual mode
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'IBKR connection failed');
       }
     } catch (error) {
       console.log('⚠️ IBKR unavailable, using virtual trading mode');
-      setIbkrConnection(prev => ({ ...prev, status: 'error' }));
+      setIbkrConnection(prev => ({ ...prev, status: 'disconnected' }));
     }
   };
 

--- a/lib/websocket-client.ts
+++ b/lib/websocket-client.ts
@@ -91,9 +91,12 @@ export class UnusualWhalesWebSocket {
       }
 
       // Connect to WebSocket endpoint
-      const wsUrl = 'wss://api.unusualwhales.com/ws';
+      const apiKey = process.env.NEXT_PUBLIC_UNUSUAL_WHALES_API_KEY;
+      const wsUrl = apiKey
+        ? `wss://api.unusualwhales.com/ws?api_key=${apiKey}`
+        : 'wss://api.unusualwhales.com/ws';
       console.log('Attempting WebSocket connection to:', wsUrl);
-      
+
       this.ws = new WebSocket(wsUrl);
 
       return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Dynamically require IBKR API modules and return virtual trading fallback when they're missing
- Send API key in Unusual Whales websocket URL so trading filters can receive real-time data
- Gracefully default front-end trading page to virtual mode when IBKR connection fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(cannot proceed: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68937768d10083208ef78dfc421c20a3