### PR TITLE
fix: handle watchlist items without stock data

### DIFF
--- a/app/dashboard/watchlist/page.tsx
+++ b/app/dashboard/watchlist/page.tsx
@@ -308,10 +308,15 @@ export default function WatchlistPage() {
             </Card>
           ) : (
             currentWatchlist?.items.map(item => {
-              const ticker = item.stock?.ticker || item.ticker || '';
+              // Handle items that may only have a ticker string or lack stock info
+              const ticker = item.stock?.ticker || item.ticker;
+              if (!ticker) {
+                return null;
+              }
+
               const quote = stockQuotes[ticker];
               const isPositive = quote?.change >= 0;
-              
+
               return (
                 <Card key={item.id} className="hover:shadow-lg transition-shadow">
                   <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- guard against watchlist entries missing a `stock` object or ticker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944e7b08248320b6e1a37213ee321e