### PR TITLE
Integrate next expiry data into watchlist

### DIFF
--- a/app/api/darkpool/[ticker]/route.ts
+++ b/app/api/darkpool/[ticker]/route.ts
@@ -1,0 +1,21 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from 'next/server';
+import { unusualWhalesAPI } from '@/lib/unusual-whales-api';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { ticker: string } }
+) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const date = searchParams.get('date') || undefined;
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    const data = await unusualWhalesAPI.getDarkpoolTrades(params.ticker, date, limit);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Darkpool API error:', error);
+    return NextResponse.json({ error: 'Failed to fetch darkpool data' }, { status: 500 });
+  }
+}

--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -21,7 +21,12 @@ export async function GET(request: NextRequest) {
         data = await unusualWhalesAPI.getStockFlowAlerts(ticker, true, true, 50);
         break;
       case 'greeks':
-        data = await unusualWhalesAPI.getStockGreeks(ticker);
+        const expiry = searchParams.get('expiry');
+        const greeksDate = searchParams.get('date');
+        if (!expiry) {
+          return NextResponse.json({ error: 'Expiry parameter is required for greeks' }, { status: 400 });
+        }
+        data = await unusualWhalesAPI.getStockGreeks(ticker, expiry, greeksDate || undefined);
         break;
       case 'oi-per-strike':
         data = await unusualWhalesAPI.getStockOIPerStrike(ticker);
@@ -32,6 +37,17 @@ export async function GET(request: NextRequest) {
       case 'net-prem-ticks':
         const date = searchParams.get('date');
         data = await unusualWhalesAPI.getStockNetPremTicks(ticker, date || undefined);
+        break;
+      case 'oi-change':
+        const oiDate = searchParams.get('date') || undefined;
+        const limit = searchParams.get('limit');
+        const order = searchParams.get('order') as 'asc' | 'desc' | null;
+        data = await unusualWhalesAPI.getStockOIChange(
+          ticker,
+          oiDate,
+          limit ? parseInt(limit, 10) : undefined,
+          order || undefined
+        );
         break;
       case 'flow-alerts':
         data = await unusualWhalesAPI.getStockFlowAlerts(ticker, true, true, 50);

--- a/app/api/stocks/[ticker]/route.ts
+++ b/app/api/stocks/[ticker]/route.ts
@@ -20,6 +20,22 @@ export async function GET(
       case 'state':
         data = await unusualWhalesAPI.getStockState(params.ticker);
         break;
+      case 'ohlc':
+        const candleSize = searchParams.get('candle_size') || '1d';
+        const date = searchParams.get('date') || undefined;
+        const endDate = searchParams.get('end_date') || undefined;
+        const limitParam = searchParams.get('limit');
+        const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+        const timeframe = searchParams.get('timeframe') || undefined;
+        data = await unusualWhalesAPI.getStockOHLC(
+          params.ticker,
+          candleSize,
+          date,
+          endDate,
+          limit,
+          timeframe
+        );
+        break;
       default:
         return NextResponse.json({ error: 'Invalid type parameter' }, { status: 400 });
     }

--- a/app/dashboard/watchlist/page.tsx
+++ b/app/dashboard/watchlist/page.tsx
@@ -35,6 +35,11 @@ interface StockQuote {
   change: number;
   changePercent: number;
   volume: number;
+  maxPain?: number;
+  nextExpiry?: string;
+  darkpoolPremium?: number;
+  oiChange?: number;
+  atmCallDelta?: number;
 }
 
 // Utility functions
@@ -120,27 +125,98 @@ export default function WatchlistPage() {
     try {
       // Fetch real stock data from API
       const quotes: Record<string, StockQuote> = {};
-      
-      // Fetch data for each ticker
+
       const promises = tickers.map(async (ticker) => {
         try {
-          const response = await fetch(`/api/stocks/${ticker}?type=state`);
-          if (response.ok) {
-            const data = await response.json();
-            // Map API response to our StockQuote interface
-            if (data) {
-              quotes[ticker] = {
-                ticker: ticker,
-                price: data.last_price || 0,
-                change: data.change || 0,
-                changePercent: data.change_percent || 0,
-                volume: data.volume || 0,
-              };
+          const [stateRes, maxPainRes, darkpoolRes, oiRes] = await Promise.all([
+            fetch(`/api/stocks/${ticker}?type=state`),
+            fetch(`/api/options?type=max-pain&ticker=${ticker}`),
+            fetch(`/api/darkpool/${ticker}`),
+            fetch(`/api/options?type=oi-change&ticker=${ticker}`)
+          ]);
+
+          let price = 0;
+          let change = 0;
+          let changePercent = 0;
+          let volume = 0;
+          if (stateRes.ok) {
+            const data = await stateRes.json();
+            price = data.last_price || 0;
+            change = data.change || 0;
+            changePercent = data.change_percent || 0;
+            volume = data.volume || 0;
+          }
+
+          let maxPain: number | undefined;
+          let nextExpiry: string | undefined;
+          if (maxPainRes.ok) {
+            const mp = await maxPainRes.json();
+            if (Array.isArray(mp.data)) {
+              const today = new Date();
+              const upcoming = mp.data
+                .map((d: any) => ({
+                  expiry: d.expiry,
+                  maxPain: parseFloat(d.max_pain),
+                }))
+                .filter((d: any) => !isNaN(new Date(d.expiry).getTime()) && new Date(d.expiry) >= today)
+                .sort((a: any, b: any) => new Date(a.expiry).getTime() - new Date(b.expiry).getTime());
+              if (upcoming.length) {
+                nextExpiry = upcoming[0].expiry;
+                maxPain = upcoming[0].maxPain;
+              }
             }
           }
+
+          let atmCallDelta: number | undefined;
+          if (nextExpiry) {
+            const greeksRes = await fetch(`/api/options?type=greeks&ticker=${ticker}&expiry=${nextExpiry}`);
+            if (greeksRes.ok) {
+              const gr = await greeksRes.json();
+              if (Array.isArray(gr.data) && gr.data.length) {
+                const closest = gr.data.reduce((prev: any, curr: any) => {
+                  return Math.abs(parseFloat(curr.strike) - price) < Math.abs(parseFloat(prev.strike) - price) ? curr : prev;
+                });
+                atmCallDelta = parseFloat(closest.call_delta);
+              }
+            }
+          }
+
+          let darkpoolPremium: number | undefined;
+          if (darkpoolRes.ok) {
+            const dp = await darkpoolRes.json();
+            if (Array.isArray(dp.data)) {
+              darkpoolPremium = dp.data.reduce(
+                (sum: number, trade: any) => sum + parseFloat(trade.premium || '0'),
+                0
+              );
+            }
+          }
+
+          let oiChange: number | undefined;
+          if (oiRes.ok) {
+            const oi = await oiRes.json();
+            if (Array.isArray(oi.data)) {
+              oiChange = oi.data.reduce(
+                (sum: number, item: any) => sum + (item.oi_diff_plain || 0),
+                0
+              );
+            }
+          }
+
+          quotes[ticker] = {
+            ticker,
+            price,
+            change,
+            changePercent,
+            volume,
+            maxPain,
+            nextExpiry,
+            darkpoolPremium,
+            oiChange,
+            atmCallDelta,
+          };
         } catch (error) {
           console.error(`Failed to fetch quote for ${ticker}:`, error);
-          // Don't add mock data - leave blank to show no data available
         }
       });
 
@@ -349,7 +425,7 @@ export default function WatchlistPage() {
                             <p className="text-sm text-gray-500">Price</p>
                             <p className="text-2xl font-bold">{formatCurrency(quote.price)}</p>
                           </div>
-                          
+
                           <div className="text-right">
                             <p className="text-sm text-gray-500">Change</p>
                             <div className={`flex items-center space-x-1 ${isPositive ? 'text-green-600' : 'text-red-600'}`}>
@@ -363,11 +439,39 @@ export default function WatchlistPage() {
                               </span>
                             </div>
                           </div>
-                          
+
                           <div className="text-right">
                             <p className="text-sm text-gray-500">Volume</p>
                             <p className="font-semibold">{(quote.volume / 1000000).toFixed(1)}M</p>
                           </div>
+
+                          {quote.oiChange !== undefined && (
+                            <div className="text-right">
+                              <p className="text-sm text-gray-500">OI Δ</p>
+                              <p className="font-semibold">{quote.oiChange.toLocaleString()}</p>
+                            </div>
+                          )}
+
+                          {quote.darkpoolPremium !== undefined && (
+                            <div className="text-right">
+                              <p className="text-sm text-gray-500">Darkpool</p>
+                              <p className="font-semibold">{formatCurrency(quote.darkpoolPremium)}</p>
+                            </div>
+                          )}
+
+                          {quote.atmCallDelta !== undefined && (
+                            <div className="text-right">
+                              <p className="text-sm text-gray-500">ATM Δ</p>
+                              <p className="font-semibold">{quote.atmCallDelta.toFixed(2)}</p>
+                            </div>
+                          )}
+
+                          {quote.maxPain !== undefined && quote.nextExpiry && (
+                            <div className="text-right">
+                              <p className="text-sm text-gray-500">Max Pain ({quote.nextExpiry})</p>
+                              <p className="font-semibold">{formatCurrency(quote.maxPain)}</p>
+                            </div>
+                          )}
                         </div>
                       )}
                       

--- a/lib/unusual-whales-api.ts
+++ b/lib/unusual-whales-api.ts
@@ -186,8 +186,41 @@ export class UnusualWhalesAPI {
     return this.getStockFlowAlerts(ticker, true, true, 50);
   }
 
-  async getStockGreeks(ticker: string) {
-    return this.makeRequest(`/stock/${ticker}/greeks`);
+  async getStockGreeks(ticker: string, expiry: string, date?: string) {
+    const params: Record<string, string> = { expiry };
+    if (date) params.date = date;
+    return this.makeRequest(`/stock/${ticker}/greeks`, { params });
+  }
+
+  async getDarkpoolTrades(ticker: string, date?: string, limit?: number) {
+    const params: Record<string, any> = {};
+    if (date) params.date = date;
+    if (limit !== undefined) params.limit = limit;
+    return this.makeRequest(`/darkpool/${ticker}`, { params });
+  }
+
+  async getStockOIChange(ticker: string, date?: string, limit?: number, order?: 'desc' | 'asc') {
+    const params: Record<string, any> = {};
+    if (date) params.date = date;
+    if (limit !== undefined) params.limit = limit;
+    if (order) params.order = order;
+    return this.makeRequest(`/stock/${ticker}/oi-change`, { params });
+  }
+
+  async getStockOHLC(
+    ticker: string,
+    candleSize: string,
+    date?: string,
+    endDate?: string,
+    limit?: number,
+    timeframe?: string
+  ) {
+    const params: Record<string, any> = {};
+    if (date) params.date = date;
+    if (endDate) params.end_date = endDate;
+    if (limit !== undefined) params.limit = limit;
+    if (timeframe) params.timeframe = timeframe;
+    return this.makeRequest(`/stock/${ticker}/ohlc/${candleSize}`, { params });
   }
 
   async getStockOIPerStrike(ticker: string) {


### PR DESCRIPTION
## Summary
- Fetch greeks for a specified expiry and add helpers for darkpool, OI change, and OHLC endpoints
- Expose darkpool, OI change, and OHLC data through API routes
- Enrich watchlist with next-expiry greeks, max pain, darkpool premium, and OI change metrics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_689454a394288320899465c772a83b6f