### PR TITLE
fix: handle missing action and refresh data

### DIFF
--- a/app/dashboard/institutions/page.tsx
+++ b/app/dashboard/institutions/page.tsx
@@ -120,8 +120,9 @@ export default function InstitutionsPage() {
     return 'text-gray-600';
   };
 
-  const getActionColor = (action: string) => {
-    switch (action.toLowerCase()) {
+  const getActionColor = (action?: string) => {
+    const normalized = action?.toLowerCase();
+    switch (normalized) {
       case 'buy':
       case 'increase':
         return 'bg-green-100 text-green-800 border-green-200';

--- a/app/dashboard/shorts/page.tsx
+++ b/app/dashboard/shorts/page.tsx
@@ -40,10 +40,10 @@ export default function ShortsPage() {
     try {
       setLoading(true);
       const [shortsRes, ftdRes, volumeRes, interestRes] = await Promise.all([
-        fetch(`/api/shorts/${ticker}?type=data`),
-        fetch(`/api/shorts/${ticker}?type=ftds`),
-        fetch(`/api/shorts/${ticker}?type=volume-ratio`),
-        fetch(`/api/shorts/${ticker}?type=interest-float`)
+        fetch(`/api/shorts/${ticker}?type=data`, { cache: 'no-store' }),
+        fetch(`/api/shorts/${ticker}?type=ftds`, { cache: 'no-store' }),
+        fetch(`/api/shorts/${ticker}?type=volume-ratio`, { cache: 'no-store' }),
+        fetch(`/api/shorts/${ticker}?type=interest-float`, { cache: 'no-store' })
       ]);
 
       if (shortsRes.ok) {


### PR DESCRIPTION
## Summary
- guard against undefined action values in institutional activity
- prevent caching in quotes/shorts API calls and refresh watchlist periodically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68949c1a38f8832093c14901c3901363