### PR TITLE
Fix watchlist quote parsing and return full flow analysis

### DIFF
--- a/app/api/flow-analysis/route.ts
+++ b/app/api/flow-analysis/route.ts
@@ -35,18 +35,8 @@ export async function GET(request: NextRequest) {
       const tickerList = tickers.split(',').map(t => t.trim().toUpperCase()).filter(Boolean);
       const analyses = await flowAnalysisService.analyzeBatch(tickerList);
 
-      // Filter for rapid changes in gamma or delta flow
-      const GAMMA_THRESHOLD = 1000;
-      const DELTA_THRESHOLD = 100000; // $100k
-      const filtered: Record<string, typeof analyses[keyof typeof analyses]> = {};
-      Object.entries(analyses).forEach(([t, data]) => {
-        if (Math.abs(data.metrics.gamma_exposure) >= GAMMA_THRESHOLD ||
-            Math.abs(data.metrics.delta_flow) >= DELTA_THRESHOLD) {
-          filtered[t] = data;
-        }
-      });
-
-      return NextResponse.json({ data: filtered });
+      // Return all analyses so the UI can display available data
+      return NextResponse.json({ data: analyses });
     }
   } catch (error) {
     console.error('Flow analysis API error:', error);

--- a/app/dashboard/watchlist/page.tsx
+++ b/app/dashboard/watchlist/page.tsx
@@ -141,19 +141,21 @@ export default function WatchlistPage() {
           let volume = 0;
           if (stateRes.ok) {
             const data = await stateRes.json();
-            price = data.last_price || 0;
-            change = data.change || 0;
-            changePercent = data.change_percent || 0;
-            volume = data.volume || 0;
+            const state = data?.data || data;
+            price = state?.last_price ?? 0;
+            change = state?.change ?? 0;
+            changePercent = state?.change_percent ?? 0;
+            volume = state?.volume ?? 0;
           }
 
           let maxPain: number | undefined;
           let nextExpiry: string | undefined;
           if (maxPainRes.ok) {
             const mp = await maxPainRes.json();
-            if (Array.isArray(mp.data)) {
+            const mpData = mp?.data?.data || mp.data;
+            if (Array.isArray(mpData)) {
               const today = new Date();
-              const upcoming = mp.data
+              const upcoming = mpData
                 .map((d: any) => ({
                   expiry: d.expiry,
                   maxPain: parseFloat(d.max_pain),
@@ -184,8 +186,9 @@ export default function WatchlistPage() {
           let darkpoolPremium: number | undefined;
           if (darkpoolRes.ok) {
             const dp = await darkpoolRes.json();
-            if (Array.isArray(dp.data)) {
-              darkpoolPremium = dp.data.reduce(
+            const dpData = dp?.data?.data || dp.data;
+            if (Array.isArray(dpData)) {
+              darkpoolPremium = dpData.reduce(
                 (sum: number, trade: any) => sum + parseFloat(trade.premium || '0'),
                 0
               );
@@ -195,8 +198,9 @@ export default function WatchlistPage() {
           let oiChange: number | undefined;
           if (oiRes.ok) {
             const oi = await oiRes.json();
-            if (Array.isArray(oi.data)) {
-              oiChange = oi.data.reduce(
+            const oiData = oi?.data?.data || oi.data;
+            if (Array.isArray(oiData)) {
+              oiChange = oiData.reduce(
                 (sum: number, item: any) => sum + (item.oi_diff_plain || 0),
                 0
               );


### PR DESCRIPTION
## Summary
- Return all tickers from flow-analysis API so earnings page can display metrics
- Parse nested API responses when fetching watchlist quotes to show price/change/volume

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint? https://nextjs.org/docs/basic-features/eslint)


------
https://chatgpt.com/codex/tasks/task_e_6894a65d7cc88320973099a90b631f0a