### PR TITLE
feat: ensure filter polling fallback

### DIFF
--- a/lib/enhanced-flow-analysis.ts
+++ b/lib/enhanced-flow-analysis.ts
@@ -35,24 +35,20 @@ export class EnhancedFlowAnalysisService {
     this.isMonitoring = true;
     tickers.forEach(ticker => this.monitoringTickers.add(ticker));
 
-    // With confirmed WebSocket access, enable ALL real-time streams
+    // Attempt to start real-time monitoring via WebSocket
     const success = await tradingFilters.startRealTimeMonitoring();
+
+    // Subscribe to ALL high-value filters for maximum earnings insight
+    const alertHandler = (alert: FlowAlert) => {
+      this.processEarningsAlert(alert, tickers);
+    };
+
+    tradingFilters.subscribeToFilter('big-money-otm', alertHandler);
+    tradingFilters.subscribeToFilter('dark-pool-correlation', alertHandler);
+    tradingFilters.subscribeToFilter('aggressive-short-term', alertHandler);
 
     if (success) {
       console.log('✅ FULL WebSocket access confirmed - enabling ALL institutional-grade filters!');
-
-      // Subscribe to ALL high-value filters for maximum earnings insight
-      tradingFilters.subscribeToFilter('big-money-otm-whales', (alert) => {
-        this.processEarningsAlert(alert, tickers);
-      });
-
-      tradingFilters.subscribeToFilter('dark-pool-correlation', (alert) => {
-        this.processEarningsAlert(alert, tickers);
-      });
-
-      tradingFilters.subscribeToFilter('aggressive-short-term', (alert) => {
-        this.processEarningsAlert(alert, tickers);
-      });
 
       // Enable real-time GEX monitoring for gamma squeeze detection
       tickers.forEach(ticker => {


### PR DESCRIPTION
## Summary
- subscribe to trading filters regardless of WebSocket status
- use API polling fallback when WebSocket connection fails

## Testing
- `UNUSUAL_WHALES_API_KEY=fake node test-direct-websocket.js`
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_6894ab04a5888320ae41e24c83f7ff09