### PR TITLE
Replace websocket tests with HTTP API calls

### DIFF
--- a/test-direct-websocket.js
+++ b/test-direct-websocket.js
@@ -1,150 +1,40 @@
-// Direct WebSocket test to diagnose connection issues
-console.log('🔍 Testing WebSocket connection to Unusual Whales...');
+// Test HTTP access to Unusual Whales API endpoints
+console.log('\u{1F50D} Testing HTTP connection to Unusual Whales...');
 
-// Check if we have the necessary environment variables
 const API_KEY = process.env.UNUSUAL_WHALES_API_KEY;
 if (!API_KEY) {
   console.error('❌ UNUSUAL_WHALES_API_KEY not found in environment');
   process.exit(1);
 }
 
-console.log('✅ API Key found, testing connection...');
-
-// Test different WebSocket URLs
-const testUrls = [
-  `wss://api.unusualwhales.com/ws?api_key=${API_KEY}`,
-  `wss://api.unusualwhales.com/ws`,
-  'wss://api.unusualwhales.com/socket',
-  'wss://stream.unusualwhales.com/ws'
-];
-
-async function testWebSocketURL(url, useHeaders = false) {
-  return new Promise((resolve) => {
-    console.log(`\n🔌 Testing: ${url.replace(API_KEY, 'API_KEY')}`);
-    
-    const options = {};
-    if (useHeaders && !url.includes('api_key=')) {
-      options.headers = {
-        'Authorization': `Bearer ${API_KEY}`,
-        'Origin': 'https://app.unusualwhales.com'
-      };
-      console.log('📋 Using Authorization header');
+async function testHTTPFlowAlerts(ticker) {
+  const url = `https://api.unusualwhales.com/api/options/${ticker}/flow-alerts`;
+  console.log(`\n🔌 Fetching: ${url}`);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        Accept: 'application/json'
+      }
+    });
+    if (!response.ok) {
+      console.log(`❌ HTTP ${response.status}: ${response.statusText}`);
+      return;
     }
-    
-    const ws = new (require('ws'))(url, options);
-    
-    const timeout = setTimeout(() => {
-      console.log('⏰ Connection timeout (10s)');
-      ws.close();
-      resolve({ success: false, error: 'Timeout' });
-    }, 10000);
-    
-    ws.on('open', () => {
-      console.log('✅ Connected successfully!');
-      clearTimeout(timeout);
-      
-      // Try to subscribe to flow-alerts
-      try {
-        ws.send(JSON.stringify({
-          action: 'subscribe',
-          channel: 'flow-alerts'
-        }));
-        console.log('📡 Sent subscription to flow-alerts');
-        
-        // Wait a bit for messages
-        setTimeout(() => {
-          ws.close();
-          resolve({ success: true, error: null });
-        }, 3000);
-        
-      } catch (e) {
-        console.log('❌ Failed to send subscription:', e.message);
-        ws.close();
-        resolve({ success: false, error: e.message });
-      }
-    });
-    
-    ws.on('message', (data) => {
-      try {
-        const parsed = JSON.parse(data.toString());
-        console.log('📨 Received message:', JSON.stringify(parsed, null, 2));
-      } catch (e) {
-        console.log('📨 Received raw data:', data.toString());
-      }
-    });
-    
-    ws.on('error', (error) => {
-      console.log('❌ Connection error:', error.message);
-      clearTimeout(timeout);
-      resolve({ success: false, error: error.message });
-    });
-    
-    ws.on('close', (code, reason) => {
-      console.log(`🔌 Connection closed: ${code} - ${reason || 'No reason'}`);
-      clearTimeout(timeout);
-      if (!timeout._destroyed) {
-        resolve({ success: false, error: `Closed: ${code}` });
-      }
-    });
-  });
-}
-
-async function testMarketHours() {
-  const now = new Date();
-  const est = new Date(now.toLocaleString("en-US", {timeZone: "America/New_York"}));
-  const hour = est.getHours();
-  const day = est.getDay(); // 0 = Sunday, 6 = Saturday
-  
-  console.log(`\n📅 Current time: ${est.toLocaleString()} EST`);
-  console.log(`📅 Day of week: ${['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][day]}`);
-  
-  // Market hours: 9:30 AM - 4:00 PM EST, Monday-Friday
-  const isWeekday = day >= 1 && day <= 5;
-  const isMarketHours = hour >= 9.5 && hour < 16;
-  const isPremarket = hour >= 4 && hour < 9.5;
-  const isAftermarket = hour >= 16 && hour < 20;
-  
-  console.log(`📊 Market Status:`);
-  console.log(`   Weekday: ${isWeekday ? '✅' : '❌'}`);
-  console.log(`   Market Hours (9:30-4:00): ${isMarketHours ? '✅' : '❌'}`);
-  console.log(`   Pre-market (4:00-9:30): ${isPremarket ? '✅' : '❌'}`);
-  console.log(`   After-market (4:00-8:00): ${isAftermarket ? '✅' : '❌'}`);
-  
-  if (!isWeekday) {
-    console.log('⚠️  WEEKEND: Limited WebSocket activity expected');
-  } else if (!isMarketHours && !isPremarket && !isAftermarket) {
-    console.log('⚠️  OVERNIGHT: Limited WebSocket activity expected');
-  } else {
-    console.log('✅ ACTIVE TRADING PERIOD: WebSocket should have activity');
+    const data = await response.json();
+    const count = Array.isArray(data.data) ? data.data.length : Array.isArray(data) ? data.length : 0;
+    console.log(`✅ Received ${count} alerts for ${ticker}`);
+  } catch (error) {
+    console.log('❌ Request failed:', error.message);
   }
-  
-  return { isWeekday, isMarketHours, isPremarket, isAftermarket };
 }
 
 async function main() {
-  try {
-    // Test market hours first
-    const marketStatus = await testMarketHours();
-    
-    // Test different WebSocket URLs
-    for (const url of testUrls) {
-      await testWebSocketURL(url, false);
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Wait between tests
-    }
-    
-    // Test with headers
-    console.log('\n🔄 Testing with Authorization headers...');
-    await testWebSocketURL('wss://api.unusualwhales.com/ws', true);
-    
-    console.log('\n🏁 WebSocket testing complete!');
-    
-    if (!marketStatus.isWeekday || (!marketStatus.isMarketHours && !marketStatus.isPremarket && !marketStatus.isAftermarket)) {
-      console.log('\n💡 RECOMMENDATION: If connections succeed but no data flows, this may be normal outside trading hours.');
-    }
-    
-  } catch (error) {
-    console.error('❌ Test failed:', error);
+  const tickers = ['AAPL', 'TSLA', 'NVDA', 'MSFT', 'SPY', 'QQQ', 'IWM'];
+  for (const ticker of tickers) {
+    await testHTTPFlowAlerts(ticker);
   }
+  console.log('\n\u{1F3C1} HTTP testing complete!');
 }
 
 main();

--- a/test-websocket-debug.js
+++ b/test-websocket-debug.js
@@ -1,56 +1,26 @@
-// Simple test to debug WebSocket flow alerts
-const { WebSocket } = require('ws');
+// Simple test to debug flow alerts using HTTP API instead of WebSocket
 const API_KEY = process.env.UNUSUAL_WHALES_API_KEY || 'your-api-key';
 
-console.log('Testing WebSocket connection...');
-
-// Test actual WebSocket connection
-const ws = new WebSocket('wss://api.unusualwhales.com/ws', {
-  headers: {
-    'Authorization': `Bearer ${API_KEY}`
-  }
-});
-
-ws.on('open', function open() {
-  console.log('✅ WebSocket connected');
-  
-  // Subscribe to flow-alerts channel
-  ws.send(JSON.stringify({ 
-    action: 'subscribe',
-    channel: 'flow-alerts'
-  }));
-  
-  console.log('📡 Subscribed to flow-alerts channel');
-});
-
-ws.on('message', function message(data) {
+async function fetchFlowAlerts(ticker = 'AAPL') {
+  console.log(`Fetching flow alerts for ${ticker} via HTTP...`);
   try {
-    const parsed = JSON.parse(data.toString());
-    console.log('📨 Raw WebSocket message:', JSON.stringify(parsed, null, 2));
-    
-    // Log specifically flow-alerts messages
-    if (Array.isArray(parsed) && parsed[0] === 'flow-alerts') {
-      console.log('🎯 FLOW ALERT DETECTED:', JSON.stringify(parsed[1], null, 2));
-      console.log('Premium:', parsed[1].total_premium || parsed[1].premium);
-      console.log('Ticker:', parsed[1].ticker);
-      console.log('Type:', parsed[1].type);
-      console.log('Side:', parsed[1].side || 'unknown');
+    const response = await fetch(`https://api.unusualwhales.com/api/options/${ticker}/flow-alerts`, {
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        Accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      console.error('HTTP error:', response.status, response.statusText);
+      return;
     }
-  } catch (e) {
-    console.log('📨 Raw data (non-JSON):', data.toString());
+
+    const data = await response.json();
+    console.log('Received flow alerts:', JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error('Request failed:', error);
   }
-});
+}
 
-ws.on('error', function error(err) {
-  console.error('❌ WebSocket error:', err);
-});
-
-ws.on('close', function close() {
-  console.log('🔌 WebSocket connection closed');
-});
-
-// Keep alive for 60 seconds to catch some messages
-setTimeout(() => {
-  console.log('⏰ Test timeout - closing connection');
-  ws.close();
-}, 60000);
+fetchFlowAlerts();


### PR DESCRIPTION
## Summary
- convert websocket debug script to fetch flow alerts via HTTP
- replace direct websocket test with HTTP polling of flow alert endpoints

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894f9e7825c8320b016b31195711c7b